### PR TITLE
Checkbox

### DIFF
--- a/blocks/checkbox.tsx
+++ b/blocks/checkbox.tsx
@@ -1,0 +1,61 @@
+import { BlockSchemaWithBlock, defaultProps } from "@blocknote/core";
+import { ReactSlashMenuItem, createReactBlockSpec } from "@blocknote/react";
+import { CheckSquare } from "lucide-react";
+
+export const CheckBoxBlockSpec = createReactBlockSpec(
+  {
+    type: "checkbox",
+    propSchema: {
+      ...defaultProps,
+      checked: {
+        default: false,
+      }
+    },
+    content: "inline",
+  },
+  {
+    render: ({ block, editor, contentRef }) => {
+      return (
+        <div className={"checkbox"}>
+          <div className="flex ml-2">
+            <input
+              type="checkbox"
+              checked={block.props.checked}
+              onChange={e => (editor.updateBlock(block, {
+                type: "checkbox",
+                props: {
+                  checked: e.target.checked
+                }
+            }))} />
+            <div style={{marginLeft: "4px"}}>
+              <div className={"inline-content"} ref={contentRef} />
+            </div>
+          </div>
+        </div>
+      );
+    },
+  }
+);
+
+export const insertCheckBoxBlock: ReactSlashMenuItem<
+  BlockSchemaWithBlock<"checkbox", typeof CheckBoxBlockSpec.config>
+> = {
+  name: "checkbox",
+  execute: (editor) => {
+    editor.insertBlocks(
+      [
+        {
+          type: "checkbox"
+        }
+      ],
+      editor.getTextCursorPosition().block,
+      "before"
+    );
+  },
+  aliases: [
+    "checkbox",
+  ],
+  group: "Work",
+  icon: <CheckSquare width="14" height="14" />,
+  hint: "Checkbox",
+}

--- a/blocks/checkbox.tsx
+++ b/blocks/checkbox.tsx
@@ -17,7 +17,7 @@ export const CheckBoxBlockSpec = createReactBlockSpec(
     render: ({ block, editor, contentRef }) => {
       return (
         <div className={"checkbox"}>
-          <div className="flex ml-2">
+          <div className="flex">
             <input
               type="checkbox"
               checked={block.props.checked}
@@ -27,7 +27,7 @@ export const CheckBoxBlockSpec = createReactBlockSpec(
                   checked: e.target.checked
                 }
             }))} />
-            <div style={{marginLeft: "4px"}}>
+            <div style={{marginLeft: "12px"}}>
               <div className={"inline-content"} ref={contentRef} />
             </div>
           </div>

--- a/blocks/checkbox.tsx
+++ b/blocks/checkbox.tsx
@@ -21,7 +21,7 @@ export const CheckBoxBlockSpec = createReactBlockSpec(
             <input
               type="checkbox"
               checked={block.props.checked}
-              onChange={e => (editor.updateBlock(block, {
+              onChange={e => (editor.isEditable && editor.updateBlock(block, {
                 type: "checkbox",
                 props: {
                   checked: e.target.checked

--- a/components/editor.tsx
+++ b/components/editor.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useTheme } from "next-themes";
-import { BlockNoteEditor, PartialBlock } from "@blocknote/core";
-import { BlockNoteView, useBlockNote } from "@blocknote/react";
+import { defaultBlockSpecs } from "@blocknote/core";
+import { BlockNoteView, getDefaultReactSlashMenuItems, useBlockNote } from "@blocknote/react";
 import "@blocknote/core/style.css";
 
 import { useEdgeStore } from "@/lib/edgestore";
+import { CheckBoxBlockSpec, insertCheckBoxBlock } from "@/blocks/checkbox";
 
 interface EditorProps {
   onChange: (value: string) => void;
@@ -25,13 +26,22 @@ const Editor = ({ onChange, initialContent, editable }: EditorProps) => {
     return response.url;
   };
 
-  const editor: BlockNoteEditor = useBlockNote({
+  const editor = useBlockNote({
     editable,
     initialContent: initialContent ? JSON.parse(initialContent) : undefined,
     onEditorContentChange: (editor) => {
       onChange(JSON.stringify(editor.topLevelBlocks, null, 2));
     },
     uploadFile: handleUpload,
+
+    blockSpecs: {
+      ...defaultBlockSpecs,
+      checkbox: CheckBoxBlockSpec,
+    },
+    slashMenuItems: [
+      ...getDefaultReactSlashMenuItems(),
+      insertCheckBoxBlock,
+    ]
   });
 
   return (


### PR DESCRIPTION
![image](https://github.com/Google-Developer-Student-Clubs-TUK/2024-Next.js-project-Daum/assets/53367179/64ec3ec8-12bf-43ed-b2dd-d01eac70d3cd)

말 그대로 체크박스를 만듭니다.

### 규칙 필요:
이 체크박스는 `/blocks` 폴더에 만들어 두었습니다. 다음 회의에서 이걸 놓을 적절한 폴더를 정해야 할 것 같습니다.

### 미래에 만들 것들: 
나중에 칸반보드쪽에서 체크박스를 파싱해서 띄워주려고 생각하고 있습니다.

https://github.com/TypeCellOS/BlockNote/pull/541
`[]` 명령어로 만들어지게 하고 싶어서 BlockNote쪽에 pr도 걸어 놓았습니다.