### PR TITLE
feature: checkbox를 여러 줄에 걸쳐 입력 가능하게 하기

### DIFF
--- a/blocks/checkbox.tsx
+++ b/blocks/checkbox.tsx
@@ -4,7 +4,7 @@ import { CheckSquare } from "lucide-react";
 
 export const CheckBoxBlockSpec = createReactBlockSpec(
   {
-    type: "checkbox",
+    type: "checkboxListItem",
     propSchema: {
       ...defaultProps,
       checked: {
@@ -16,13 +16,13 @@ export const CheckBoxBlockSpec = createReactBlockSpec(
   {
     render: ({ block, editor, contentRef }) => {
       return (
-        <div className={"checkbox"}>
+        <div className={"checkboxListItem"}>
           <div className="flex">
             <input
               type="checkbox"
               checked={block.props.checked}
               onChange={e => (editor.isEditable && editor.updateBlock(block, {
-                type: "checkbox",
+                type: "checkboxListItem",
                 props: {
                   checked: e.target.checked
                 }
@@ -38,13 +38,13 @@ export const CheckBoxBlockSpec = createReactBlockSpec(
 );
 
 export const insertCheckBoxBlock: ReactSlashMenuItem<
-  BlockSchemaWithBlock<"checkbox", typeof CheckBoxBlockSpec.config>
+  BlockSchemaWithBlock<"checkboxListItem", typeof CheckBoxBlockSpec.config>
 > = {
   name: "checkbox",
   execute: (editor) => {
     editor.updateBlock(
       editor.getTextCursorPosition().block, {
-        type: "checkbox",
+        type: "checkboxListItem",
         props: { checked: false }
       }
     );

--- a/components/editor.tsx
+++ b/components/editor.tsx
@@ -36,7 +36,7 @@ const Editor = ({ onChange, initialContent, editable }: EditorProps) => {
 
     blockSpecs: {
       ...defaultBlockSpecs,
-      checkbox: CheckBoxBlockSpec,
+      checkboxListItem: CheckBoxBlockSpec,
     },
     slashMenuItems: [
       ...getDefaultReactSlashMenuItems(),


### PR DESCRIPTION
https://github.com/TypeCellOS/BlockNote/blob/b6c5ce26ab74e8b64759abff570bdcc9eccddd19/packages/core/src/blocks/ListItemBlockContent/NumberedListItemBlockContent/NumberedListItemBlockContent.ts#L54

코드 따라가다 보니까 블록 type이 "ListItem"으로 끝나는지만 확인하는 것 같길래, 체크박스의 타입 이름을 checkboxListItem으로 바꿨더니 정상 작동합니다.

...

라이브러리에 하드코딩이 너무 많아요...


!BREAKING: convex documents 테이블의 content 속 checkbox 타입 값들이 깨집니다.